### PR TITLE
Update Dockerfile

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get install -qq -y --ignore-missing \
   pkg-config                                \
   protobuf-compiler                         \
   libprotobuf-dev                           \
+  libcurl4-openssl-dev                      \
+  nlohmann-json3-dev                        \
   cmake
 
 # The following arguments would be passed from docker-compose.yml


### PR DESCRIPTION

Fixes #.

## Changes

to build it succesfully,  these two package should be installed : libcurl4-openssl-dev and nlohmann-json3-dev

